### PR TITLE
Fix Apktool resource decoding bugs

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 .DS_Store
 .gadgetCache/
+__pycache__/

--- a/APK.py
+++ b/APK.py
@@ -550,13 +550,7 @@ class APK:
                     count += 1
         Log.verbose(f" Forced {count} private resource refs to public")
 
-    def _fix_apktool_error(self, stderr: str) -> bool:
-        pattern = re.compile(r"W:\s+(?P<path>.*?):\d+:\s+error:\s+attribute\s+android:(?P<attr>[^\s]+)\s+not found\.")
-        matches = list(pattern.finditer(stderr))
-
-        if not matches:
-            return False
-
+    def _fix_apktool_namespaces(self, matches):
         Log.info("Detected resource namespace mismatch, trying to resolve automatically")
 
         count = 0
@@ -575,4 +569,75 @@ class APK:
             except Exception as e:
                 Log.abort(e)
         Log.info(f"Fixed {count} broken namespaces, restarting build")
-        return True
+
+    def _fix_apktool_duplicates(self, matches):
+        Log.info("Detected duplicate attribute error, trying to resolve automatically")
+
+        # Matches duplicates attributes, and groups the first attribute occurence (\1), the duplicate (\2) and anything in between (\3)
+        dup_pattern = re.compile(r'(\b([a-zA-Z0-9_:]+)="[^"]*")(.*?)\b\2="[^"]*"')
+
+        count = 0
+        for m in matches:
+            path = m.group("path")
+            data = ""
+            try:
+                with open(path, "r", encoding="utf-8") as f:
+                    data = f.read()
+                if data and dup_pattern.search(data):
+                    while dup_pattern.search(data):
+                        # Rewrites contents without the duplicate attribute in \2
+                        data = dup_pattern.sub(r"\1\3", data)
+
+                    with open(path, "w", encoding="utf-8") as f:
+                        f.write(data)
+                    count += 1
+
+            except Exception as e:
+                Log.abort(e)
+        Log.info(f"Removed {count} duplicates, restarting build")
+
+    def _fix_apktool_incompatible_flags(self, matches):
+        Log.info("Detected incompatible flags error, trying to resolve automatically")
+
+        count = 0
+        for m in matches:
+            path, attr, value = m.group("path"), m.group("attr"), m.group("value")
+            incomp_pattern = re.compile(rf'\s+(?:[a-zA-Z0-9_]+:)?{attr}="0x0"')
+            data = ""
+            try:
+                with open(path, "r", encoding="utf-8") as f:
+                    data = f.read()
+                if data:
+                    data = incomp_pattern.sub("", data)
+                with open(path, "w", encoding="utf-8") as f:
+                    f.write(data)
+                count += 1
+
+            except Exception as e:
+                Log.abort(e)
+        Log.info(f"Removed {count} incompatible flags, restarting build")
+
+    def _fix_apktool_error(self, stderr: str) -> bool:
+        # Matches "attribue android:example not found" error
+        namespace_error = re.compile(r"W:\s+(?P<path>.*?):\d+:\s+error:\s+attribute\s+android:(?P<attr>[^\s]+)\s+not found\.")
+        matches = list(namespace_error.finditer(stderr))
+        if matches:
+            self._fix_apktool_namespaces(matches)
+            return True
+
+        # Matches "duplicate attribute" error
+        duplicates_error = re.compile(r"W:\s+(?P<path>.*?):\d+:\s+error:\s+duplicate\s+attribute\.")
+        matches = list(duplicates_error.finditer(stderr))
+        if matches:
+            self._fix_apktool_duplicates(matches)
+            return True
+
+        # Matches "incompatible with attribute" error
+        incompatible_flags_error = re.compile(r"W:\s+(?P<path>.*?):\d+:\s*error:\s*'(?P<value>[^']+)'\s*is incompatible with attribute\s*(?P<attr>\w+).*?\[(?P<allowed>[^\]]+)\]")
+        matches = list(incompatible_flags_error.finditer(stderr))
+        if matches:
+            self._fix_apktool_incompatible_flags(matches)
+            return True
+
+        return False
+

--- a/APK.py
+++ b/APK.py
@@ -231,8 +231,12 @@ class APK:
         Log.verbose(f"[apktool] {exe} {' '.join(args)}\n{cp.stdout}")
         if cp.returncode != 0:
             Log.verbose(cp.stderr)
-        if ok_required and cp.returncode != 0:
-            Log.abort(f"apktool failed: \n\n{exe}{' '.join(args)}\n\n" + cp.stdout +"\n\n---\n\n"+ cp.stderr)
+        while ok_required and cp.returncode != 0:
+            fixed = self._fix_apktool_error(cp.stderr)
+            if fixed:
+                cp = subprocess.run([exe, *args], input="\r\n", text=True, capture_output=True)
+            else:
+                Log.abort(f"apktool failed: \n\n{exe}{' '.join(args)}\n\n" + cp.stdout +"\n\n---\n\n"+ cp.stderr)
 
     def _run(self, args: List[str], ok_required: bool = False):
         Log.verbose(f"[{args[0]}] {' '.join(args)}")
@@ -495,7 +499,7 @@ class APK:
                     r'(?m)^(\s*\.method\s+static\s+constructor\s+<clinit>\(\)V\s*$)',
                     r'\1\n    .registers 1',
                     clinit_block,
-                    count=1,
+                        count=1,
                 )
 
             # Insert the load instructions after the (possibly updated) .registers line.
@@ -545,3 +549,30 @@ class APK:
                         fh.write(ns)
                     count += 1
         Log.verbose(f" Forced {count} private resource refs to public")
+
+    def _fix_apktool_error(self, stderr: str) -> bool:
+        pattern = re.compile(r"W:\s+(?P<path>.*?):\d+:\s+error:\s+attribute\s+android:(?P<attr>[^\s]+)\s+not found\.")
+        matches = list(pattern.finditer(stderr))
+
+        if not matches:
+            return False
+
+        Log.info("Detected resource namespace mismatch, trying to resolve automatically")
+
+        count = 0
+        for m in matches:
+            path, attr = m.group("path"), m.group("attr")
+            data = ""
+            try:
+                with open(path, "r", encoding="utf-8") as f:
+                    data = f.read()
+                if data:
+                    data = data.replace(f"android:{attr}", attr)
+                    with open(path, "w", encoding="utf-8") as f:
+                        f.write(data)
+                    count += 1
+
+            except Exception as e:
+                Log.abort(e)
+        Log.info(f"Fixed {count} broken namespaces, restarting build")
+        return True

--- a/APK.py
+++ b/APK.py
@@ -5,6 +5,7 @@ from urllib.parse import urlsplit
 from pathlib import Path
 from typing import List, Optional
 from Log import Log
+from ErrorHandler import ErrorHandler
 from packaging.version import parse as parse_version
 
 # If you put FridaGadget.py next to this file, this import will work.
@@ -19,7 +20,7 @@ class APK:
    
     NULL_DECODED_DRAWABLE_COLOR = "#000000ff"
 
-    def __init__(self, apk_path: str, workdir: Optional[str] = None, verbose: bool = False):
+    def __init__(self, apk_path: str, workdir: Optional[str] = None, verbose: bool = False, fix_aggressive: bool = False):
         self.apk_path = os.path.abspath(apk_path)
         self.verbose = verbose
         self._check_exists(self.apk_path)
@@ -27,6 +28,7 @@ class APK:
         self.workdir = workdir or self._tmpbase.name
         Path(self.workdir).mkdir(parents=True, exist_ok=True)
         self.has_been_merged = False
+        self.error_handler = ErrorHandler(fix_aggressive)
 
     # ---------- Creation ----------
     @classmethod
@@ -231,8 +233,10 @@ class APK:
         Log.verbose(f"[apktool] {exe} {' '.join(args)}\n{cp.stdout}")
         if cp.returncode != 0:
             Log.verbose(cp.stderr)
+
         while ok_required and cp.returncode != 0:
-            fixed = self._fix_apktool_error(cp.stderr)
+            # Pass error to handler (action picked based on --fix-aggressive flag)
+            fixed = self.error_handler.handle(cp.stderr)
             if fixed:
                 cp = subprocess.run([exe, *args], input="\r\n", text=True, capture_output=True)
             else:
@@ -549,95 +553,3 @@ class APK:
                         fh.write(ns)
                     count += 1
         Log.verbose(f" Forced {count} private resource refs to public")
-
-    def _fix_apktool_namespaces(self, matches):
-        Log.info("Detected resource namespace mismatch, trying to resolve automatically")
-
-        count = 0
-        for m in matches:
-            path, attr = m.group("path"), m.group("attr")
-            data = ""
-            try:
-                with open(path, "r", encoding="utf-8") as f:
-                    data = f.read()
-                if data:
-                    data = data.replace(f"android:{attr}", attr)
-                    with open(path, "w", encoding="utf-8") as f:
-                        f.write(data)
-                    count += 1
-
-            except Exception as e:
-                Log.abort(e)
-        Log.info(f"Fixed {count} broken namespaces, restarting build")
-
-    def _fix_apktool_duplicates(self, matches):
-        Log.info("Detected duplicate attribute error, trying to resolve automatically")
-
-        # Matches duplicates attributes, and groups the first attribute occurence (\1), the duplicate (\2) and anything in between (\3)
-        dup_pattern = re.compile(r'(\b([a-zA-Z0-9_:]+)="[^"]*")(.*?)\b\2="[^"]*"')
-
-        count = 0
-        for m in matches:
-            path = m.group("path")
-            data = ""
-            try:
-                with open(path, "r", encoding="utf-8") as f:
-                    data = f.read()
-                if data and dup_pattern.search(data):
-                    while dup_pattern.search(data):
-                        # Rewrites contents without the duplicate attribute in \2
-                        data = dup_pattern.sub(r"\1\3", data)
-
-                    with open(path, "w", encoding="utf-8") as f:
-                        f.write(data)
-                    count += 1
-
-            except Exception as e:
-                Log.abort(e)
-        Log.info(f"Removed {count} duplicates, restarting build")
-
-    def _fix_apktool_incompatible_flags(self, matches):
-        Log.info("Detected incompatible flags error, trying to resolve automatically")
-
-        count = 0
-        for m in matches:
-            path, attr, value = m.group("path"), m.group("attr"), m.group("value")
-            incomp_pattern = re.compile(rf'\s+(?:[a-zA-Z0-9_]+:)?{attr}="0x0"')
-            data = ""
-            try:
-                with open(path, "r", encoding="utf-8") as f:
-                    data = f.read()
-                if data:
-                    data = incomp_pattern.sub("", data)
-                with open(path, "w", encoding="utf-8") as f:
-                    f.write(data)
-                count += 1
-
-            except Exception as e:
-                Log.abort(e)
-        Log.info(f"Removed {count} incompatible flags, restarting build")
-
-    def _fix_apktool_error(self, stderr: str) -> bool:
-        # Matches "attribue android:example not found" error
-        namespace_error = re.compile(r"W:\s+(?P<path>.*?):\d+:\s+error:\s+attribute\s+android:(?P<attr>[^\s]+)\s+not found\.")
-        matches = list(namespace_error.finditer(stderr))
-        if matches:
-            self._fix_apktool_namespaces(matches)
-            return True
-
-        # Matches "duplicate attribute" error
-        duplicates_error = re.compile(r"W:\s+(?P<path>.*?):\d+:\s+error:\s+duplicate\s+attribute\.")
-        matches = list(duplicates_error.finditer(stderr))
-        if matches:
-            self._fix_apktool_duplicates(matches)
-            return True
-
-        # Matches "incompatible with attribute" error
-        incompatible_flags_error = re.compile(r"W:\s+(?P<path>.*?):\d+:\s*error:\s*'(?P<value>[^']+)'\s*is incompatible with attribute\s*(?P<attr>\w+).*?\[(?P<allowed>[^\]]+)\]")
-        matches = list(incompatible_flags_error.finditer(stderr))
-        if matches:
-            self._fix_apktool_incompatible_flags(matches)
-            return True
-
-        return False
-

--- a/ErrorHandler.py
+++ b/ErrorHandler.py
@@ -30,7 +30,7 @@ class ErrorHandler:
         return False
 
     def _handle_apktool_namespaces(self, matches: List[Match]) -> bool:
-        Log.warn("Detected resource namespace mismatch. This issue is likely related to https://github.com/iBotPeaches/Apktool/pull/4137\nTo solve this, you can build Apktool from source, update to 3.0.3 (once it is released), or run patch-apk with --fix-aggressive")
+        Log.warn("Detected resource namespace mismatch. This issue is likely related to https://github.com/iBotPeaches/Apktool/pull/4137\nTo solve this, you can update Apktool to 3.0.3 or higher, or run patch-apk with --fix-aggressive")
 
         if not self.fix_aggressive:
             return False
@@ -86,7 +86,7 @@ class ErrorHandler:
         return True
 
     def _handle_apktool_incompatible_flags(self, matches: List[Match]) -> bool:
-        Log.warn("Detected incompatible flags error. This issue is likely related to https://github.com/iBotPeaches/Apktool/pull/4140\nTo solve this, you can build Apktool from source, update to 3.0.3 (once it is released), or run patch-apk with --fix-aggressive")
+        Log.warn("Detected incompatible flags error. This issue is likely related to https://github.com/iBotPeaches/Apktool/pull/4140\nTo solve this, you can update Apktool to 3.0.3 or higher, or run patch-apk with --fix-aggressive")
 
         if not self.fix_aggressive:
             return False

--- a/ErrorHandler.py
+++ b/ErrorHandler.py
@@ -1,0 +1,112 @@
+import re, os
+from typing import List, Match
+from Log import Log
+
+class ErrorHandler:
+    def __init__(self, fix_aggressive: bool = False):
+        self.fix_aggressive = fix_aggressive
+
+    def handle(self, stderr: str) -> bool:
+        # Matches "attribue android:example not found" error
+        namespace_error = re.compile(r"W:\s+(?P<path>.*?):\d+:\s+error:\s+attribute\s+android:(?P<attr>[^\s]+)\s+not found\.")
+        matches = list(namespace_error.finditer(stderr))
+        if matches:
+            return self._handle_apktool_namespaces(matches)
+
+        # Matches "duplicate attribute" error
+        duplicates_error = re.compile(r"W:\s+(?P<path>.*?):\d+:\s+error:\s+duplicate\s+attribute\.")
+        matches = list(duplicates_error.finditer(stderr))
+        if matches:
+            self._handle_apktool_duplicates(matches)
+            return True
+
+        # Matches "incompatible with attribute" error
+        incompatible_flags_error = re.compile(r"W:\s+(?P<path>.*?):\d+:\s*error:\s*'(?P<value>[^']+)'\s*is incompatible with attribute\s*(?P<attr>\w+).*?\[(?P<allowed>[^\]]+)\]")
+        matches = list(incompatible_flags_error.finditer(stderr))
+        if matches:
+            self._handle_apktool_incompatible_flags(matches)
+            return True
+
+        return False
+
+    def _handle_apktool_namespaces(self, matches: List[Match]) -> bool:
+        Log.warn("Detected resource namespace mismatch. This issue is likely related to https://github.com/iBotPeaches/Apktool/pull/4137\nTo solve this, you can build Apktool from source, update to 3.0.3 (once it is released), or run patch-apk with --fix-aggressive")
+
+        if not self.fix_aggressive:
+            return False
+
+        Log.info("Trying to resolve automatically...")
+        count = 0
+        for m in matches:
+            path, attr = m.group("path"), m.group("attr")
+            data = ""
+            try:
+                with open(path, "r", encoding="utf-8") as f:
+                    data = f.read()
+                if data:
+                    data = data.replace(f"android:{attr}", attr)
+                    with open(path, "w", encoding="utf-8") as f:
+                        f.write(data)
+                    count += 1
+
+            except Exception as e:
+                Log.abort(e)
+        Log.info(f"Fixed {count} broken namespaces, restarting build")
+        return True
+
+    def _handle_apktool_duplicates(self, matches: List[Match]) -> bool:
+        Log.warn("Detected duplicate attribute error, this issue has no known fix on Apktool side and is likely caused by heavy obfuscation\nTo solve this, you can run patch-apk with --fix-aggressive")
+
+        if not self.fix_aggressive:
+            return False
+
+        Log.info("Trying to resolve automatically...")
+        # Matches duplicates attributes, and groups the first attribute occurence (\1), the duplicate (\2) and anything in between (\3)
+        dup_pattern = re.compile(r'(\b([a-zA-Z0-9_:]+)="[^"]*")(.*?)\b\2="[^"]*"')
+
+        count = 0
+        for m in matches:
+            path = m.group("path")
+            data = ""
+            try:
+                with open(path, "r", encoding="utf-8") as f:
+                    data = f.read()
+                if data and dup_pattern.search(data):
+                    while dup_pattern.search(data):
+                        # Rewrites contents without the duplicate attribute in \2
+                        data = dup_pattern.sub(r"\1\3", data)
+
+                    with open(path, "w", encoding="utf-8") as f:
+                        f.write(data)
+                    count += 1
+
+            except Exception as e:
+                Log.abort(e)
+        Log.info(f"Removed {count} duplicates, restarting build")
+        return True
+
+    def _handle_apktool_incompatible_flags(self, matches: List[Match]) -> bool:
+        Log.warn("Detected incompatible flags error. This issue is likely related to https://github.com/iBotPeaches/Apktool/pull/4140\nTo solve this, you can build Apktool from source, update to 3.0.3 (once it is released), or run patch-apk with --fix-aggressive")
+
+        if not self.fix_aggressive:
+            return False
+
+        Log.info("Trying to resolve automatically...")
+        count = 0
+        for m in matches:
+            path, attr, value = m.group("path"), m.group("attr"), m.group("value")
+            incomp_pattern = re.compile(rf'\s+(?:[a-zA-Z0-9_]+:)?{attr}="0x0"')
+            data = ""
+            try:
+                with open(path, "r", encoding="utf-8") as f:
+                    data = f.read()
+                if data:
+                    data = incomp_pattern.sub("", data)
+                with open(path, "w", encoding="utf-8") as f:
+                    f.write(data)
+                count += 1
+
+            except Exception as e:
+                Log.abort(e)
+        Log.info(f"Removed {count} incompatible flags, restarting build")
+        return True

--- a/patch-apk.py
+++ b/patch-apk.py
@@ -93,6 +93,7 @@ def main():
     ap.add_argument("--no-install", action="store_true", help="Do not install to device at the end")
     ap.add_argument("--keep-splits", action="store_true", help="Keep split APKs when extracting")
     ap.add_argument("--save-apk", help="Copy final APK to this path")
+    ap.add_argument("--fix-aggressive", action="store_true", help="Attempt to fix known Apktool errors automatically")
     ap.add_argument("-v", "--verbose", action="store_true")
     args = ap.parse_args()
 
@@ -158,10 +159,10 @@ def main():
 
         if len(local_apks) == 1:
             Log.info("Single APK detected")
-            base = APK(local_apks[0])
+            base = APK(local_apks[0], fix_aggressive=args.fix_aggressive)
         else:
             Log.info(f"Split APK set detected ({len(local_apks)})")
-            apks = [APK(p) for p in local_apks]
+            apks = [APK(p, fix_aggressive=args.fix_aggressive) for p in local_apks]
 
             # Find base APK (heuristic: filename containing "base", else first)
             base = next((p for p in apks if "base.apk" in p.apk_path), apks[0])


### PR DESCRIPTION
On obfuscated APKs, Apktool will struggle with resource decoding and throw different kinds of errors, which propagate to patch-apk when trying to rebuild an APK. We can catch the error logs and fix them programmatically, and re-run the build command.

> Since Apktool's error printing is capped to 20 errors, we can do trial and error to fix them 20 at a time. The time to fully fix can be increased a lot depending on the amount of times it has to rebuild.

### Error 1 : namespacing error

```
W: /tmp/tmp6ug84c13/apk_decoded/res/animator/APKTOOL_RENAMED_0x7f020002.xml:4: error: attribute android:APKTOOL_RENAMED_0x7f0409ce not found.
```

See [this issue](https://github.com/iBotPeaches/Apktool/issues/3533) for details about this error. Basically, it assigns the `android:` namespace to properties that should be assigned `app:`.

From patch-apk, we can retrieve the filename and attribute that caused the error, then remove the `android:` prefix.

### Error 2 : duplicate attributes

```
W: /tmp/tmpppawd3a1/apk_decoded/res/font/alternative.xml:4: error: duplicate attribute.
W: /tmp/tmpppawd3a1/apk_decoded/res/font/alternative.xml: error: file failed to compile.
```

We can match duplicates inside their files with a regex and keep only one occurence.

### Error 3 : incompatible flags

```
W: /tmp/tmpofrmlkwo/apk_decoded/res/layout/telco_buy_image_header.xml:9: error: '0x0' is incompatible with attribute foregroundGravity (attr) flags [bottom=80, center=17, center_horizontal=1, center_vertical=16, clip_horizontal=8, clip_vertical=128, fill=119, fill_horizontal=7, fill_vertical=112, left=3, right=5, top=48].
```

Enumerations with no actual value will be decoded as an invalid `0x0` value. We can remove this attribute completely.

Example output on a test app:

```
$ patch-apk --extract-only com.example.myapp
[*] Using package: com.example.myapp
[*] Pulled 2 APK(s)
[*]  - base.apk
[*]  - split_config.arm64_v8a.apk
[*] Split APK set detected (2)
[*] Disassembling base.apk with apktool
[*] Disassembling split_config.arm64_v8a.apk with apktool
[*] Merging split APKs into base
[*] Detected duplicate attribute error, trying to resolve automatically
[*] Removed 5 duplicates, restarting build
[*] Detected resource namespace mismatch, trying to resolve automatically
[*] Fixed 20 broken namespaces, restarting build
[*] Detected resource namespace mismatch, trying to resolve automatically
[*] Fixed 20 broken namespaces, restarting build
[*] Detected resource namespace mismatch, trying to resolve automatically
[*] Fixed 20 broken namespaces, restarting build
[*] Detected resource namespace mismatch, trying to resolve automatically
[*] Fixed 19 broken namespaces, restarting build
[*] Detected resource namespace mismatch, trying to resolve automatically
[*] Fixed 5 broken namespaces, restarting build
[*] Detected incompatible flags error, trying to resolve automatically
[*] Removed 1 incompatible flags, restarting build
[*] Saved APK: com.example.myapp.apk
```