### PR TITLE
Update patch-apk.py

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,6 +12,9 @@ An APK patcher, for use with [objection](https://github.com/sensepost/objection)
 
 ### Changelog
 
+* **29th June 2026:** 
+  * Updated to work on windows
+
 * **4th April 2026:**
  * Update for compatibility with apktool 3.x which no longer has `--main-classes-only`
 

--- a/patch-apk.py
+++ b/patch-apk.py
@@ -134,7 +134,13 @@ def main():
             Log.info(f" - {os.path.basename(p)}")
 
         # Test if apktool is version 3.0.2 or newer
-        apktool_version = subprocess.run(["apktool", "-version"], capture_output=True, text=True).stdout.strip()
+        apktool_version = subprocess.run(["apktool", "-version"], shell=True, capture_output=True, text=True, input="\n").stdout.split('\n')
+
+        if len(apktool_version) < 1: 
+            Log.abort("getting apktool version had an unexpected error")
+
+        apktool_version = apktool_version[0].strip()
+        
         if parse_version(apktool_version) < parse_version("3.0.2"):
             Log.abort(f"apktool version 3.0.2 or newer is required, found {apktool_version}")
             return

--- a/patch-apk.py
+++ b/patch-apk.py
@@ -14,10 +14,22 @@ def sign_with_apksigner(apk_path: str):
     DEBUG_KS_NAME  = "patchapk.jks"
     DEBUG_KS_ALIAS = "patchapk"
     DEBUG_KS_PASS  = "patchapk" 
+  
     script_dir = os.path.dirname(os.path.realpath(__file__))
     ks_path = os.path.join(script_dir, DEBUG_KS_NAME)
+
+    command_name = "apksigner.bat" if os.name == "nt" else "apksigner"
+    apksigner_path = shutil.which(command_name)
+
+    if apksigner_path is None:
+        raise RuntimeError(
+            f"{command_name} was not found. Add the Android SDK "
+            "build-tools directory to PATH."
+        )
+
     cmd = [
-        "apksigner", "sign",
+        apksigner_path,
+        "sign",
         "--ks", ks_path,
         "--ks-key-alias", DEBUG_KS_ALIAS,
         "--ks-pass", f"pass:{DEBUG_KS_PASS}",
@@ -29,9 +41,9 @@ def sign_with_apksigner(apk_path: str):
         "--v4-signing-enabled=false",
         apk_path,
     ]
-    Log.verbose("[apksigner] " + " ".join(cmd))
-    cp = subprocess.run(cmd, check=True)
 
+    Log.verbose("[apksigner] " + subprocess.list2cmdline(cmd))
+    subprocess.run(cmd, check=True)
 
 def choose_package(adb: ADBHelper, pattern: str) -> str:
     matches = adb.get_packages(pattern)
@@ -134,7 +146,11 @@ def main():
             Log.info(f" - {os.path.basename(p)}")
 
         # Test if apktool is version 3.0.2 or newer
-        apktool_version = subprocess.run("apktool -version", shell=True, capture_output=True, text=True, input="\n").stdout.split('\n')[0].strip()
+        command_name = "apktool.bat" if os.name == "nt" else "apktool"
+        apktool_path = shutil.which(command_name)
+
+
+        apktool_version = subprocess.run([apktool_path, "-version"], capture_output=True, text=True, input="\n").stdout.strip().split("\n")[0]
 
         if parse_version(apktool_version) < parse_version("3.0.2"):
             Log.abort(f"apktool version 3.0.2 or newer is required, found {apktool_version}")

--- a/patch-apk.py
+++ b/patch-apk.py
@@ -134,13 +134,8 @@ def main():
             Log.info(f" - {os.path.basename(p)}")
 
         # Test if apktool is version 3.0.2 or newer
-        apktool_version = subprocess.run(["apktool", "-version"], shell=True, capture_output=True, text=True, input="\n").stdout.split('\n')
+        apktool_version = subprocess.run("apktool -version", shell=True, capture_output=True, text=True, input="\n").stdout.split('\n')[0].strip()
 
-        if len(apktool_version) < 1: 
-            Log.abort("getting apktool version had an unexpected error")
-
-        apktool_version = apktool_version[0].strip()
-        
         if parse_version(apktool_version) < parse_version("3.0.2"):
             Log.abort(f"apktool version 3.0.2 or newer is required, found {apktool_version}")
             return


### PR DESCRIPTION
fix: fixes a bug reading apktool from windows path leads to an error not found, added execute in shell with input '\n' to exit out of the apktool.bat wrapper, ensure we only read first line if available else give appropriate error.